### PR TITLE
fix: Use latest instead of master as a docker tag

### DIFF
--- a/scripts/push-container.sh
+++ b/scripts/push-container.sh
@@ -4,7 +4,8 @@ set -e
 
 APP_NAME="bitbucket2insights"
 
-BRANCH=${TRAVIS_BRANCH}
+BRANCH=$([ "${TRAVIS_BRANCH}" = "master" ] && echo "latest" || echo "${TRAVIS_BRANCH}")
+
 if [ -n "${VERSION}" ]; then
   BRANCH=${VERSION}
 fi


### PR DESCRIPTION
# Description

Using `latest` as a docker tag when the `travis` create a build based on `master` branch.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
